### PR TITLE
Don't rely on implicit binding creation of setglobal!

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -1143,6 +1143,19 @@ function start! end
 
 function start!(mod::Module = Main, ip::IP4 = ip4_cli(Main.ARGS);
     threads::Int64 = 1, router_threads::UnitRange{Int64} = -2:threads)
+
+    # Inject bindings we will use into the module
+    if !isdefined(mod, :server)
+        Core.eval(mod, :(global server, data, routes))
+
+        # Switch to the latest world where the bindings are available
+        invokelatest(_start!, mod, ip, threads, router_threads)
+    else
+        _start!(mod, ip, threads, router_threads)
+    end
+end
+
+function _start!(mod::Module, ip::IP4, threads::Int64, router_threads::UnitRange{Int64})
     IP = Sockets.InetAddr(parse(IPAddr, ip.ip), ip.port)
     server::Sockets.TCPServer = Sockets.listen(IP)
     mod.server = server
@@ -1210,6 +1223,7 @@ function generate_router(mod::Module, ip::IP4)
     mod.routes = Vector{AbstractRoute}()
     loaded = []
     for name in server_ns
+        isdefined(mod, name) || continue
         f = getfield(mod, name)
         T = typeof(f)
         if T <: AbstractExtension


### PR DESCRIPTION
The `mod.sym = val` syntax is not supposed to be able to create new bindings if `mod.sym` does not yet exist. The error check for this was accidentally dropped in Julia 1.9, but will likely be put back in 1.11 [1]. This uses Core.eval/invokelatest to achieve the same effect using the recommeded replacement. As a general note, the way this package uses bindings is clever, but not particularly idiomatic in Julia. Not saying you can't do it, but I would recommend revisiting if at least the injected bindings could perhaps be replaced by something like an IdDict.

[1] https://github.com/JuliaLang/julia/pull/54678